### PR TITLE
internal/function: implement ref_name functions

### DIFF
--- a/cmd/gitquery/query_base.go
+++ b/cmd/gitquery/query_base.go
@@ -39,7 +39,8 @@ func (c *cmdQueryBase) buildDatabase() error {
 	}
 
 	c.engine.AddDatabase(gitquery.NewDatabase(c.name, &pool))
-	return function.Register(c.engine.Catalog)
+	function.Register(c.engine.Catalog)
+	return nil
 }
 
 func (c *cmdQueryBase) executeQuery(sql string) (sql.Schema, sql.RowIter, error) {

--- a/cmd/gitquery/query_base.go
+++ b/cmd/gitquery/query_base.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/src-d/gitquery"
 	"github.com/src-d/gitquery/internal/format"
+	"github.com/src-d/gitquery/internal/function"
 
 	"gopkg.in/src-d/go-git.v4/utils/ioutil"
 	sqle "gopkg.in/src-d/go-mysql-server.v0"
@@ -38,7 +39,7 @@ func (c *cmdQueryBase) buildDatabase() error {
 	}
 
 	c.engine.AddDatabase(gitquery.NewDatabase(c.name, &pool))
-	return err
+	return function.Register(c.engine.Catalog)
 }
 
 func (c *cmdQueryBase) executeQuery(sql string) (sql.Schema, sql.RowIter, error) {

--- a/internal/function/is_remote.go
+++ b/internal/function/is_remote.go
@@ -1,0 +1,55 @@
+package function
+
+import (
+	"reflect"
+
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+)
+
+// IsRemote checks the given string is a tag name.
+type IsRemote struct {
+	expression.UnaryExpression
+}
+
+// NewIsRemote creates a new IsRemote function.
+func NewIsRemote(e sql.Expression) *IsRemote {
+	return &IsRemote{expression.UnaryExpression{Child: e}}
+}
+
+var _ sql.Expression = (*IsRemote)(nil)
+
+// Eval implements the expression interface.
+func (f *IsRemote) Eval(row sql.Row) (interface{}, error) {
+	val, err := f.Child.Eval(row)
+	if err != nil {
+		return nil, err
+	}
+
+	if val == nil {
+		return false, nil
+	}
+
+	name, ok := val.(string)
+	if !ok {
+		return nil, sql.ErrInvalidType.New(reflect.TypeOf(val).String())
+	}
+
+	return plumbing.ReferenceName(name).IsRemote(), nil
+}
+
+// Name implements the Expression interface.
+func (IsRemote) Name() string {
+	return "is_remote"
+}
+
+// TransformUp implements the Expression interface.
+func (f IsRemote) TransformUp(fn func(sql.Expression) sql.Expression) sql.Expression {
+	return NewIsRemote(fn(f.Child))
+}
+
+// Type implements the Expression interface.
+func (IsRemote) Type() sql.Type {
+	return sql.Boolean
+}

--- a/internal/function/is_remote.go
+++ b/internal/function/is_remote.go
@@ -14,7 +14,7 @@ type IsRemote struct {
 }
 
 // NewIsRemote creates a new IsRemote function.
-func NewIsRemote(e sql.Expression) *IsRemote {
+func NewIsRemote(e sql.Expression) sql.Expression {
 	return &IsRemote{expression.UnaryExpression{Child: e}}
 }
 

--- a/internal/function/is_remote_test.go
+++ b/internal/function/is_remote_test.go
@@ -1,0 +1,40 @@
+package function
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+)
+
+func TestIsRemote(t *testing.T) {
+	f := NewIsRemote(expression.NewGetField(0, sql.Text, "name", true))
+
+	testCases := []struct {
+		name     string
+		row      sql.Row
+		expected bool
+		err      bool
+	}{
+		{"null", sql.NewRow(nil), false, false},
+		{"not a branch", sql.NewRow("foo bar"), false, false},
+		{"not remote branch", sql.NewRow("refs/heads/foo"), false, false},
+		{"remote branch", sql.NewRow("refs/remotes/foo/bar"), true, false},
+		{"mismatched type", sql.NewRow(1), false, true},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			val, err := f.Eval(tt.row)
+			if tt.err {
+				require.Error(err)
+				require.True(sql.ErrInvalidType.Is(err))
+			} else {
+				require.NoError(err)
+				require.Equal(tt.expected, val)
+			}
+		})
+	}
+}

--- a/internal/function/is_tag.go
+++ b/internal/function/is_tag.go
@@ -14,7 +14,7 @@ type IsTag struct {
 }
 
 // NewIsTag creates a new IsTag function.
-func NewIsTag(e sql.Expression) *IsTag {
+func NewIsTag(e sql.Expression) sql.Expression {
 	return &IsTag{expression.UnaryExpression{Child: e}}
 }
 

--- a/internal/function/is_tag.go
+++ b/internal/function/is_tag.go
@@ -1,0 +1,55 @@
+package function
+
+import (
+	"reflect"
+
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+)
+
+// IsTag checks the given string is a tag name.
+type IsTag struct {
+	expression.UnaryExpression
+}
+
+// NewIsTag creates a new IsTag function.
+func NewIsTag(e sql.Expression) *IsTag {
+	return &IsTag{expression.UnaryExpression{Child: e}}
+}
+
+var _ sql.Expression = (*IsTag)(nil)
+
+// Eval implements the expression interface.
+func (f *IsTag) Eval(row sql.Row) (interface{}, error) {
+	val, err := f.Child.Eval(row)
+	if err != nil {
+		return nil, err
+	}
+
+	if val == nil {
+		return false, nil
+	}
+
+	name, ok := val.(string)
+	if !ok {
+		return nil, sql.ErrInvalidType.New(reflect.TypeOf(val).String())
+	}
+
+	return plumbing.ReferenceName(name).IsTag(), nil
+}
+
+// Name implements the Expression interface.
+func (IsTag) Name() string {
+	return "is_tag"
+}
+
+// TransformUp implements the Expression interface.
+func (f IsTag) TransformUp(fn func(sql.Expression) sql.Expression) sql.Expression {
+	return NewIsTag(fn(f.Child))
+}
+
+// Type implements the Expression interface.
+func (IsTag) Type() sql.Type {
+	return sql.Boolean
+}

--- a/internal/function/is_tag_test.go
+++ b/internal/function/is_tag_test.go
@@ -1,0 +1,40 @@
+package function
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+	"gopkg.in/src-d/go-mysql-server.v0/sql/expression"
+)
+
+func TestIsTag(t *testing.T) {
+	f := NewIsTag(expression.NewGetField(0, sql.Text, "name", true))
+
+	testCases := []struct {
+		name     string
+		row      sql.Row
+		expected bool
+		err      bool
+	}{
+		{"null", sql.NewRow(nil), false, false},
+		{"not a ref name", sql.NewRow("foo bar"), false, false},
+		{"not a tag ref", sql.NewRow("refs/heads/v1.x"), false, false},
+		{"a tag", sql.NewRow("refs/tags/v1.0.0"), true, false},
+		{"mismatched type", sql.NewRow(1), false, true},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			val, err := f.Eval(tt.row)
+			if tt.err {
+				require.Error(err)
+				require.True(sql.ErrInvalidType.Is(err))
+			} else {
+				require.NoError(err)
+				require.Equal(tt.expected, val)
+			}
+		})
+	}
+}

--- a/internal/function/registry.go
+++ b/internal/function/registry.go
@@ -1,0 +1,19 @@
+package function
+
+import "gopkg.in/src-d/go-mysql-server.v0/sql"
+
+var functions = map[string]interface{}{
+	"is_tag":    NewIsTag,
+	"is_remote": NewIsRemote,
+}
+
+// Register all the gitquery functions in the SQL catalog.
+func Register(c *sql.Catalog) error {
+	for k, v := range functions {
+		if err := c.RegisterFunction(k, v); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/function/registry.go
+++ b/internal/function/registry.go
@@ -2,18 +2,14 @@ package function
 
 import "gopkg.in/src-d/go-mysql-server.v0/sql"
 
-var functions = map[string]interface{}{
-	"is_tag":    NewIsTag,
-	"is_remote": NewIsRemote,
+var functions = map[string]sql.Function{
+	"is_tag":    sql.Function1(NewIsTag),
+	"is_remote": sql.Function1(NewIsRemote),
 }
 
 // Register all the gitquery functions in the SQL catalog.
-func Register(c *sql.Catalog) error {
+func Register(c *sql.Catalog) {
 	for k, v := range functions {
-		if err := c.RegisterFunction(k, v); err != nil {
-			return err
-		}
+		c.RegisterFunction(k, v)
 	}
-
-	return nil
 }

--- a/internal/function/registry_test.go
+++ b/internal/function/registry_test.go
@@ -10,7 +10,7 @@ import (
 func TestRegister(t *testing.T) {
 	require := require.New(t)
 	catalog := sql.NewCatalog()
-	require.NoError(Register(catalog))
+	Register(catalog)
 
 	for fn := range functions {
 		_, err := catalog.Function(fn)

--- a/internal/function/registry_test.go
+++ b/internal/function/registry_test.go
@@ -1,0 +1,19 @@
+package function
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-mysql-server.v0/sql"
+)
+
+func TestRegister(t *testing.T) {
+	require := require.New(t)
+	catalog := sql.NewCatalog()
+	require.NoError(Register(catalog))
+
+	for fn := range functions {
+		_, err := catalog.Function(fn)
+		require.NoError(err, "expected to find function: %s", fn)
+	}
+}


### PR DESCRIPTION
Closes #9 
Closes #8 

Adds the `is_tag` and `is_remote` functions along with a function to register them on a catalog.
Perhaps on the future we should move the logic of initializing the sqle engine to the `gitquery` package where you just pass a path to  a `New` function and it returns everything setup.